### PR TITLE
Update strategy to use the Portable Contacts format

### DIFF
--- a/lib/profile.js
+++ b/lib/profile.js
@@ -1,6 +1,8 @@
 /**
  * Parse profile.
  *
+ * The Outlook API response is transformed to the Portable Contacts format, defines for PassportJS.
+ *
  * @param {Object|String} json
  * @return {Object}
  * @api private
@@ -11,11 +13,15 @@ exports.parse = function(json) {
   }
   
   var profile = {};
-  profile.Id = json.Id;
-  profile.EmailAddress = json.EmailAddress;
-  profile.DisplayName = json.DisplayName;
-  profile.Alias = json.Alias;
-  profile.MailboxGuid = json.MailboxGuid;
+  profile.id = json.Id;
+  if (json.EmailAddress) {
+    profile.emails = [ {
+      value: json.EmailAddress, type: "home"
+    }];
+  }
+  profile.displayName = json.DisplayName;
+  profile.alias = json.Alias;
+  profile.mailboxGuid = json.MailboxGuid;
 
   return profile;
 };

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -136,7 +136,7 @@ Strategy.prototype.userProfile = function (accessToken, done) {
       return done(new Error('Failed to parse user profile'));
     }
     
-    var profile = json;
+    var profile = Profile.parse(json);
     profile.provider = 'windowslive';
     profile._raw = body;
     profile._json = json;

--- a/test/profile.test.js
+++ b/test/profile.test.js
@@ -19,11 +19,12 @@ describe('profile.parse', function() {
     });
     
     it('should parse profile', function() {
-      expect(profile.Id).to.equal('0dbf6616-20bd-4cbd-860d-47c5b7953e76@c512ffd1-581d-4dc0-a672-faee32f6387c');
-      expect(profile.EmailAddress).to.equal('AllieB@oauthplay.onmicrosoft.com');
-      expect(profile.DisplayName).to.equal('Allie Bellew');
-      expect(profile.Alias).to.equal('AllieB');
-      expect(profile.MailboxGuid).to.equal('8d899a1e-bde4-4946-8817-005e6f11d36d');
+      expect(profile.id).to.equal('0dbf6616-20bd-4cbd-860d-47c5b7953e76@c512ffd1-581d-4dc0-a672-faee32f6387c');
+      expect(profile.emails[0].type).to.equal('home');
+      expect(profile.emails[0].value).to.equal('AllieB@oauthplay.onmicrosoft.com');
+      expect(profile.displayName).to.equal('Allie Bellew');
+      expect(profile.alias).to.equal('AllieB');
+      expect(profile.mailboxGuid).to.equal('8d899a1e-bde4-4946-8817-005e6f11d36d');
     });
   });
   

--- a/test/strategy.profile.test.js
+++ b/test/strategy.profile.test.js
@@ -48,11 +48,12 @@ describe('Strategy#userProfile', function() {
     it('should parse profile', function() {
       expect(profile.provider).to.equal('windowslive');
     
-      expect(profile.Id).to.equal('0dbf6616-20bd-4cbd-860d-47c5b7953e76@c512ffd1-581d-4dc0-a672-faee32f6387c');
-      expect(profile.EmailAddress).to.equal('AllieB@oauthplay.onmicrosoft.com');
-      expect(profile.DisplayName).to.equal('Allie Bellew');
-      expect(profile.Alias).to.equal('AllieB');
-      expect(profile.MailboxGuid).to.equal('8d899a1e-bde4-4946-8817-005e6f11d36d');
+      expect(profile.id).to.equal('0dbf6616-20bd-4cbd-860d-47c5b7953e76@c512ffd1-581d-4dc0-a672-faee32f6387c');
+      expect(profile.emails[0].type).to.equal('home');
+      expect(profile.emails[0].value).to.equal('AllieB@oauthplay.onmicrosoft.com');
+      expect(profile.displayName).to.equal('Allie Bellew');
+      expect(profile.alias).to.equal('AllieB');
+      expect(profile.mailboxGuid).to.equal('8d899a1e-bde4-4946-8817-005e6f11d36d');
     });
   
     it('should set raw property', function() {


### PR DESCRIPTION
For the strategy to be compatible with other libraries using passport, the profile has to comply with the Portable Contact format. 
It is referenced in http://passportjs.org/docs/profile

You can read a draft of the spec in 
http://hdknr.github.io/docs/identity/poco.html

I changed the profile parser to change from the Microsoft format to the PoCo format. In the strategy, the profile parser is called (it was not called). 

I stumbled with this bug while trying to use this passport integration with the loopback-passport-component. With this change the profile can be consumed without any problem.
