### PR TITLE
Support loginHint authorization parameter

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -97,6 +97,11 @@ Strategy.prototype.authorizationParams = function (options) {
     }
   });
 
+  // https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-implicit-grant-flow
+  if (options.loginHint) {
+    params['login_hint'] = options.loginHint;
+  }
+
   return params;
 };
 

--- a/test/strategy.test.js
+++ b/test/strategy.test.js
@@ -17,3 +17,42 @@ describe('Strategy', function() {
   });
   
 });
+
+describe('Strategy.authorizationParams', function() {
+
+  var strategy = new OutlookStrategy({
+      clientID: 'ABC123',
+      clientSecret: 'secret'
+    },
+    function() {});
+
+  it('returns "locale" param', function() {
+    var params = { locale: "en" };
+    expect(strategy.authorizationParams(params)).to.deep.equal(params);
+  });
+
+  it('returns "display" param', function() {
+    var params = { display: "some" };
+    expect(strategy.authorizationParams(params)).to.deep.equal(params);
+  });
+
+  it('returns "login_hint" param', function() {
+    var params = { loginHint: "some@email.com" };
+    expect(strategy.authorizationParams(params)).to.deep.equal({ login_hint: params.loginHint });
+  });
+
+  it('returns a combination of valid params', function() {
+    var params = {
+      some: "other param",
+      display: "some",
+      loginHint: "some@email.com",
+      locale: "en",
+      invalid: "param"
+    };
+    expect(strategy.authorizationParams(params)).to.deep.equal({
+      display: params.display,
+      login_hint: params.loginHint,
+      locale: params.locale
+    });
+  });
+});


### PR DESCRIPTION
Just like Google's API, Microsoft support `login_hint` query param on the authorization flow.

More information about the parameter on this page: https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-implicit-grant-flow

I've used the same pattern found in [`passport-google-oauth2`](https://github.com/jaredhanson/passport-google-oauth2/blob/master/lib/strategy.js#L144) which converts the parameter's name from camelcase to underscore.

Test coverage before

```
=============================== Coverage summary ===============================
Statements   : 90% ( 54/60 )
Branches     : 85.71% ( 24/28 )
Functions    : 62.5% ( 5/8 )
Lines        : 90% ( 54/60 )
================================================================================
```

and after

```
=============================== Coverage summary ===============================
Statements   : 98.39% ( 61/62 )
Branches     : 93.33% ( 28/30 )
Functions    : 87.5% ( 7/8 )
Lines        : 98.39% ( 61/62 )
================================================================================
```