### PR TITLE
added prompt parameter

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -102,6 +102,10 @@ Strategy.prototype.authorizationParams = function (options) {
     params['login_hint'] = options.loginHint;
   }
 
+  if (options.prompt) {
+    params['prompt'] = options.prompt;
+  }
+
   return params;
 };
 


### PR DESCRIPTION
Prompt indicates the type of user interaction that is required. The only valid values at this time are 'login', 'none', 'select_account', and 'consent'. prompt=login will force the user to enter their credentials on that request, negating single-sign on. prompt=none is the opposite - it will ensure that the user isn't presented with any interactive prompt whatsoever. If the request can't be completed silently via single-sign on, the Microsoft identity platform endpoint will return an error. prompt=select_account sends the user to an account picker where all of the accounts remembered in the session will appear. prompt=consent will trigger the OAuth consent dialog after the user signs in, asking the user to grant permissions to the ap